### PR TITLE
fix: 支持使用create or replace创建函数、存储过程、视图以及包等语句

### DIFF
--- a/sql/engines/oracle.py
+++ b/sql/engines/oracle.py
@@ -457,25 +457,25 @@ class OracleEngine(EngineBase):
             object_name = re.match(
                 r"^alter\s+table\s(.+?)\s", sql, re.M | re.IGNORECASE
             ).group(1)
-        elif re.match(r"^create\s+function\s", sql, re.M | re.IGNORECASE):
+        elif re.match(r"^create\s+[or\s]+[replace\s]+function\s", sql, re.M | re.IGNORECASE):
             object_name = re.match(
-                r"^create\s+function\s(.+?)(\s|\()", sql, re.M | re.IGNORECASE
+                r"^create\s+[or\s]+[replace\s]+function\s(.+?)(\s|\()", sql, re.M | re.IGNORECASE
             ).group(1)
-        elif re.match(r"^create\s+view\s", sql, re.M | re.IGNORECASE):
+        elif re.match(r"^create\s+[or\s]+[replace\s]+view\s", sql, re.M | re.IGNORECASE):
             object_name = re.match(
-                r"^create\s+view\s(.+?)\s", sql, re.M | re.IGNORECASE
+                r"^create\s+[or\s]+[replace\s]+view\s(.+?)\s", sql, re.M | re.IGNORECASE
             ).group(1)
-        elif re.match(r"^create\s+procedure\s", sql, re.M | re.IGNORECASE):
+        elif re.match(r"^create\s+[or\s]+[replace\s]+procedure\s", sql, re.M | re.IGNORECASE):
             object_name = re.match(
-                r"^create\s+procedure\s(.+?)\s", sql, re.M | re.IGNORECASE
+                r"^create\s+[or\s]+[replace\s]+procedure\s(.+?)\s", sql, re.M | re.IGNORECASE
             ).group(1)
-        elif re.match(r"^create\s+package\s+body", sql, re.M | re.IGNORECASE):
+        elif re.match(r"^create\s+[or\s]+[replace\s]+package\s+body", sql, re.M | re.IGNORECASE):
             object_name = re.match(
-                r"^create\s+package\s+body\s(.+?)\s", sql, re.M | re.IGNORECASE
+                r"^create\s+[or\s]+[replace\s]+package\s+body\s(.+?)\s", sql, re.M | re.IGNORECASE
             ).group(1)
-        elif re.match(r"^create\s+package\s", sql, re.M | re.IGNORECASE):
+        elif re.match(r"^create\s+[or\s]+[replace\s]+package\s", sql, re.M | re.IGNORECASE):
             object_name = re.match(
-                r"^create\s+package\s(.+?)\s", sql, re.M | re.IGNORECASE
+                r"^create\s+[or\s]+[replace\s]+package\s(.+?)\s", sql, re.M | re.IGNORECASE
             ).group(1)
         else:
             return object_name.strip()


### PR DESCRIPTION
原来代码只支持使用create创建函数、存储过程、视图以及包，使用create or replace创建时获取不到对象名导致报错，实际运维中上线SQL大多使用create or replace方式，修改后同时支持使用create 和 create or replace两个方式。